### PR TITLE
Add full view tray menu option

### DIFF
--- a/LeapOVRPassthrough/LeapOVRPassthrough.cpp
+++ b/LeapOVRPassthrough/LeapOVRPassthrough.cpp
@@ -28,6 +28,7 @@
 #define TRAYMENU_OVERLAY_TRANSPARENT 10
 #define TRAYMENU_TOGGLE_DISTORTION_MAP 11
 #define TRAYMENU_TOGGLE_WIDTH 12
+#define TRAYMENU_SET_FULL_VIEW 13
 
 GLuint display_fullscreenQuadVAO;
 GLuint display_fullscreenQuadBuffer;
@@ -235,6 +236,7 @@ void showTrayMenu(HWND hWnd, POINT *curpos, int wDefaultItem) {
 	InsertMenu(hPopup, pos++, MF_BYPOSITION | MF_STRING, TRAYMENU_OVERLAY_TRANSPARENT, L"Set overlay to be transparent");
 	InsertMenu(hPopup, pos++, MF_BYPOSITION | MF_STRING, TRAYMENU_TOGGLE_DISTORTION_MAP, L"Toggle distortion correction");
 	InsertMenu(hPopup, pos++, MF_BYPOSITION | MF_STRING, TRAYMENU_TOGGLE_WIDTH, L"Toggle smaller overlay");
+	InsertMenu(hPopup, pos++, MF_BYPOSITION | MF_STRING, TRAYMENU_SET_FULL_VIEW, L"Set overlay to cover entire screen");
 
 	InsertMenu(hPopup, pos++, MF_BYPOSITION | MF_SEPARATOR, 0, 0);
 
@@ -314,6 +316,10 @@ static LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 				case TRAYMENU_TOGGLE_WIDTH: {
 					float currentWidth = vrController->getOverlayWidth();
 					vrController->setOverlayWidth((currentWidth > 0.4) ? 0.3 : 0.5);
+					return 0;
+				}
+				case TRAYMENU_SET_FULL_VIEW: {
+					vrController->setOverlayWidth(1.0);
 					return 0;
 				}
 			}

--- a/LeapOVRPassthrough/LeapOVRPassthrough.vcxproj
+++ b/LeapOVRPassthrough/LeapOVRPassthrough.vcxproj
@@ -43,7 +43,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/LeapOVRPassthrough/LeapOVRPassthrough.vcxproj
+++ b/LeapOVRPassthrough/LeapOVRPassthrough.vcxproj
@@ -30,13 +30,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -49,7 +49,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
This PR adds a new tray menu item for setting the overlay ratio to 1.0, allowing it to stretch over the entire view of the screen. This is useful for my use case, which is to use it to see my DJ controller and have my vision more synced to where my arms/hands are IRL.